### PR TITLE
Introduced parameter for OpFlex vlan subinterface's MTU.

### DIFF
--- a/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
@@ -4,6 +4,7 @@ class ciscoaci::opflex(
   $aci_apic_infra_subnet_gateway = '10.0.0.30',
   $aci_apic_infra_anycast_address = '10.0.0.32',
   $aci_apic_infravlan = '4093',
+  $aci_apic_uplink_interface_mtu = '9000'
   $aci_opflex_ovs_bridge = 'br-fabric',
   $aci_opflex_encap_mode = 'vxlan',
 

--- a/ciscoaci-puppet/ciscoaci/templates/osnetconfig.yaml.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/osnetconfig.yaml.erb
@@ -4,7 +4,7 @@ network_config:
     device: <%= @aci_opflex_uplink_interface %>
     vlan_id: <%= @aci_apic_infravlan %>
     use_dhcp: true
-    mtu: 1600
+    mtu: <%= @aci_apic_uplink_interface_mtu %>
     routes:
       -
         ip_netmask: 224.0.0.0/4


### PR DESCRIPTION
Before this commit setting is hard coded in the .erb dhcp configuration file to 1600 bytes, this change introduced a lookup of a TripleO configurable parameter.

On high speed networks (like 100GbE interfaces) large MTU makes a _huge_ impact on performance.

This needs https://github.com/noironetworks/tripleo-ciscoaci/pull/6