### PR TITLE
Don't use renderer-specific cache dir

### DIFF
--- a/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
@@ -18,7 +18,7 @@ class ciscoaci::opflex(
   $opflex_virtual_router_mac = '00:22:bd:f8:19:ff',
   $opflex_virtual_dhcp_enabled = 'true',
   $opflex_virtual_dhcp_mac = '00:22:bd:f8:19:ff',
-  $opflex_cache_dir = '/var/lib/opflex-agent-ovs/openvswitch/ids',
+  $opflex_cache_dir = '/var/lib/opflex-agent-ovs/ids',
   $opflex_target_bridge_to_patch = 'br-ex',
 ) {
 


### PR DESCRIPTION
The ganga agent now uses a common id's directory for caching.