### PR TITLE
auto restart mcast-daemon

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -55,6 +55,7 @@ stopasgroup=true
 startsecs=10
 startretries=3
 stopwaitsecs=10
+autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE
 user=root


### PR DESCRIPTION
The multicast-daemon should restart automatically when the opflex-agent container restarts.