### PR TITLE
Fix for aim-aid entering FATAL state because of restarts

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/aim_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/aim_supervisord.conf.erb
@@ -27,7 +27,7 @@ strip_ansi = false
 command=/usr/bin/aim-aid --config-file=/etc/aim/aim.conf --log-file=/var/log/aim/aim-aid.log
 exitcodes=0,2
 stopasgroup=true
-startsecs=10
+startsecs=0
 startretries=3
 stopwaitsecs=10
 autorestart=true


### PR DESCRIPTION
Set startseecs to 0 so it tries indefinitely.