### PR TITLE
Add ability to disable opflex-agent features

### DIFF
--- a/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
@@ -11,6 +11,7 @@ class ciscoaci::opflex(
   $opflex_log_level = 'debug2',
   $opflex_peer_port = '8009',
   $opflex_ssl_mode = 'encrypted',
+  $opflex_disabled_features,
   $opflex_endpoint_dir = '/var/lib/opflex-agent-ovs/endpoints',
   $opflex_encap_iface = 'br-fab_vxlan0',
   $opflex_remote_port = '8472',

--- a/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs-vlan.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs-vlan.conf.erb
@@ -27,6 +27,10 @@
 
     },
 
+    "feature": {
+        "disabled": <%= @opflex_disabled_features %>
+    },
+
     "endpoint-sources": {
         "filesystem": ["<%= @opflex_endpoint_dir %>"]
     },

--- a/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs.conf.erb
@@ -27,6 +27,10 @@
 
     },
 
+    "feature": {
+        "disabled": <%= @opflex_disabled_features %>
+    },
+
     "endpoint-sources": {
         "filesystem": ["<%= @opflex_endpoint_dir %>"]
     },


### PR DESCRIPTION
The opflex-agent depends on features in the vSwitch from the
underlying distibution. Some distributions provide older versions
of the vSwitch, which lack support for features needed by the opflex-agent.
In order to ensure itneroperability with these distributions, a flag was
added to the opflex-agent to disable features that aren't supported by
the underlying distribution.

This adds the configuration of that list to the opflex-agent configuration.