### PR TITLE
Add OVS monitor

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -34,6 +34,9 @@ stdout_logfile=NONE
 stderr_logfile=NONE
 user=root
 
+[program:monitor-ovs]
+command=/bin/sh -c "while true; do sleep 5; if [ $(ls /var/run/openvswitch/ | wc -l) = 0 ]; then kill $(ps -ef | grep opflex_supervisor[d] | awk '{print $3}'); fi; done"
+
 <% if @opflex_enable_bond_watch == true %>
 [program:bond-watch]
 command=/usr/bin/apic-bond-watch <%= @aci_opflex_uplink_interface %>


### PR DESCRIPTION
The docker container for the opflex-agent needs valid file handles/sockets
for OVS. If OVS, which is outside the container, gets restarted, the file
handles in the container are invalidated. This adds a monitor that checks
to see if the file handles exist, and if they don't, kills supervisord,
which will restart the container, and refresh the file handles.