### PR TITLE
Remove user from supervisord config

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/aim_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/aim_supervisord.conf.erb
@@ -33,7 +33,6 @@ stopwaitsecs=10
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE
-user=root
 
 [program:aim-event]
 command=/usr/bin/aim-event-service-polling --config-file=/etc/aim/aim.conf --log-file=/var/log/aim/aim-event-service-polling.log
@@ -45,7 +44,6 @@ stopwaitsecs=10
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE
-user=root
 
 [program:aim-rpc]
 command=/usr/bin/aim-event-service-rpc --config-file=/etc/aim/aim.conf --log-file=/var/log/aim/aim-event-service-rpc.log
@@ -57,4 +55,3 @@ stopwaitsecs=10
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE
-user=root

--- a/ciscoaci-puppet/ciscoaci/templates/lldp_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/lldp_supervisord.conf.erb
@@ -32,7 +32,6 @@ startretries=3
 stopwaitsecs=10
 stdout_logfile=NONE
 stderr_logfile=NONE
-user=root
 
 [program:neutron-cisco-apic-host-agent]
 command=/usr/bin/neutron-cisco-apic-host-agent --config-file=/etc/neutron/neutron.conf --config-file=/usr/share/neutron/neutron-dist.conf --config-file=/etc/neutron/opflex-agent/apic_topology_service.ini --config-dir=/etc/neutron/conf.d/common --log-file=/var/log/neutron/cisco-apic-host-agent.log
@@ -43,4 +42,3 @@ startretries=3
 stopwaitsecs=10
 stdout_logfile=NONE
 stderr_logfile=NONE
-user=root

--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -32,7 +32,6 @@ startretries=3
 stopwaitsecs=10
 stdout_logfile=NONE
 stderr_logfile=NONE
-user=root
 
 [program:monitor-ovs]
 command=/bin/sh -c "while true; do sleep 5; if [ $(ls /var/run/openvswitch/ | wc -l) = 0 ]; then kill $(ps -ef | grep opflex_supervisor[d] | awk '{print $3}'); fi; done"
@@ -47,7 +46,6 @@ startretries=3
 stopwaitsecs=10
 stdout_logfile=NONE
 stderr_logfile=NONE
-user=root
 <% end %>
 
 
@@ -61,7 +59,6 @@ stopwaitsecs=10
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE
-user=root
 
 [program:neutron-opflex-agent]
 command=/usr/bin/neutron-opflex-agent --config-file /usr/share/neutron/neutron-dist.conf --config-file /etc/neutron/neutron.conf --log-file /var/log/neutron/neutron-opflex-agent.log
@@ -73,7 +70,6 @@ startretries=3
 stopwaitsecs=10
 stdout_logfile=NONE
 stderr_logfile=NONE
-user=neutron
 
 <% if @aci_opflex_encap_mode == "vxlan" %>
 [program:ovs-vsctl]


### PR DESCRIPTION
The user field is removed from supervisord configuration, so that
the user who launches supervisord will be used instead.