### PR TITLE
Fix opflex-agent sequencing

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -24,7 +24,7 @@ nocleanup = false
 strip_ansi = false
 
 [program:opflex-agent]
-command=/bin/sh -c "sleep 40 && /usr/bin/opflex_agent --log /var/log/opflex/opflex-agent.log -c /etc/opflex-agent-ovs/opflex-agent-ovs.conf -c /etc/opflex-agent-ovs/plugins.conf.d -c /etc/opflex-agent-ovs/conf.d"
+command=/bin/sh -c "ovs-vsctl wait-until bridge br-int && ovs-vsctl wait-until bridge br-fabric && /usr/bin/opflex_agent --log /var/log/opflex/opflex-agent.log -c /etc/opflex-agent-ovs/opflex-agent-ovs.conf -c /etc/opflex-agent-ovs/plugins.conf.d -c /etc/opflex-agent-ovs/conf.d"
 exitcodes=0,2
 stopasgroup=true
 startsecs=10


### PR DESCRIPTION
The opflex-agent needs to wait until the OVS bridges that it manages
(br-int and br-fabric) exist before starting, or else it won't ever
know that the bridges exist, and therefore won't ever connect to them
and program flow-mods into their tables (it doesn't have the ability
to get async notifications from OVSDB). This patch adds configuration in
supervisord that causes it to wait until the bridges exist before
starting the opflex_agent.