### PR TITLE
Added parameter AciPhysDomMappings to override default physdom mapping

### DIFF
--- a/ciscoaci-puppet/ciscoaci/lib/puppet/parser/functions/collect_physdoms.rb
+++ b/ciscoaci-puppet/ciscoaci/lib/puppet/parser/functions/collect_physdoms.rb
@@ -1,0 +1,15 @@
+module Puppet::Parser::Functions
+  newfunction(:collect_physdoms, :type => :rvalue) do |args|
+    pll = args[0]
+    physn = args[1]
+    physdom = ''
+    pll.each do |val|
+        my_split = val.split(':')
+        if(my_split[0] == physn)
+          return(my_split[1])
+        end
+    end
+    return ("pdom_" + physn)
+  end
+end
+

--- a/ciscoaci-puppet/ciscoaci/manifests/aim_config.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/aim_config.pp
@@ -13,6 +13,7 @@ class ciscoaci::aim_config(
   $aci_opflex_vlan_range = '',
   $aci_host_links = {},
   $physical_device_mappings = '',
+  $aci_phys_dom_mappings = '',
   $aci_scope_names = 'False',
   $aci_scope_infra = 'False',
   $neutron_network_vlan_ranges = undef,
@@ -105,7 +106,8 @@ class ciscoaci::aim_config(
   if $nvr != "[]" {
      class {'ciscoaci::aim_physdoms':
        neutron_network_vlan_ranges => $neutron_network_vlan_ranges,
-       aci_host_links => $aci_host_links
+       aci_host_links => $aci_host_links,
+       aci_phys_dom_mappings => $aci_phys_dom_mappings
      }
   }
 

--- a/ciscoaci-puppet/ciscoaci/manifests/aim_physdoms.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/aim_physdoms.pp
@@ -1,6 +1,7 @@
 class ciscoaci::aim_physdoms(
   $neutron_network_vlan_ranges = [],
-  $aci_host_links = {}
+  $aci_host_links = {},
+  $aci_phys_dom_mappings   = []
 ) inherits ::ciscoaci::params
 {
 
@@ -8,7 +9,8 @@ class ciscoaci::aim_physdoms(
   $hosts = collect_hostnames($aci_host_links)
   $physnets = collect_physnets($neutron_network_vlan_ranges)
   ciscoaci::physdom {$physnets:
-     hosts => $hosts
+     hosts => $hosts,
+     my_physdoms => $aci_phys_dom_mappings
   }
 
 }

--- a/ciscoaci-puppet/ciscoaci/manifests/physdom.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/physdom.pp
@@ -1,9 +1,10 @@
 define ciscoaci::physdom(
   $hosts
+  $my_physdoms
 ) {
   #$pnet_l = split($name, ':')
   #$pnet = $pnet_l[0]
-  $physdom = sprintf("pdom_%s", $name)
+  $physdom = collect_physdoms($my_physdoms, $name)
   aimctl_config {
     #"apic_physical_network:$pnet/hosts": value => $hosts;
     #"apic_physical_network:$pnet/segment_type": value => 'vlan';


### PR DESCRIPTION
By default system maps physdoms with name pdom_<physnet> per physnet.
This change will allow user to override it with custom name.