### PR TITLE
Fix missing definition

### DIFF
--- a/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
@@ -1,4 +1,5 @@
 class ciscoaci::opflex(
+  $package_ensure = 'present',
   $aci_apic_systemid,
   $aci_opflex_uplink_interface,
   $opflex_enable_bond_watch,


### PR DESCRIPTION
The definition for package_ensure was missing for opflex.