### PR TITLE
Add opflex-agent restarts

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/neutron_opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/neutron_opflex_supervisord.conf.erb
@@ -36,3 +36,7 @@ stderr_logfile=NONE
 
 [program:monitor-ovs]
 command=/bin/sh -c "while true; do sleep 5; if [ $(ls /var/run/openvswitch/ | wc -l) = 0 ]; then kill $(ps -ef | grep opflex_supervisor[d] | awk '{print $3}'); fi; done"
+
+[eventlistener:restart-opflex-agent]
+events=PROCESS_STATE_STARTING
+command=/bin/sh -c "sleep 40 && echo $(date) >> /var/lib/opflex-agent-ovs/restarts/reboot.conf"

--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -24,7 +24,7 @@ nocleanup = false
 strip_ansi = false
 
 [program:opflex-agent]
-command=/bin/sh -c "ovs-vsctl wait-until bridge br-int && ovs-vsctl wait-until bridge br-fabric && /usr/bin/opflex_agent --log /var/log/opflex/opflex-agent.log -c /etc/opflex-agent-ovs/opflex-agent-ovs.conf -c /etc/opflex-agent-ovs/plugins.conf.d -c /etc/opflex-agent-ovs/conf.d"
+command=/bin/sh -c "ovs-vsctl wait-until bridge br-int && ovs-vsctl wait-until bridge br-fabric && /usr/bin/opflex_agent --log /var/log/opflex/opflex-agent.log -w -c /etc/opflex-agent-ovs/opflex-agent-ovs.conf -c /etc/opflex-agent-ovs/plugins.conf.d -c /etc/opflex-agent-ovs/conf.d -c /var/lib/opflex-agent-ovs/restarts"
 exitcodes=0,2
 stopasgroup=true
 startsecs=10


### PR DESCRIPTION
Due to race conditions between the neutron-opflex-agent and the
opflex-agent restarts, we enxure they are sequenced by using the
restart feature in the opflex-agent. When a process in the neutron
opflex agent's container enters the RUNNING state, the opflex agent
is restarted after a 40 second delay, ensuring that there is no
conflict due to agent restarts.