### PR TITLE
Bugfix: Use correct template for lldp healthcheck

### DIFF
--- a/ciscoaci-puppet/ciscoaci/manifests/lldp.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/lldp.pp
@@ -15,7 +15,7 @@ class ciscoaci::lldp(
 
    file {'/etc/neutron/ciscoaci/lldp_healthcheck':
      mode => '0755',
-     content => template('ciscoaci/lldp_supervisord.conf.erb'),
+     content => template('ciscoaci/lldp_healthcheck.erb'),
      require => File['/etc/neutron/ciscoaci'],
    }
 


### PR DESCRIPTION
Similar fix as https://github.com/noironetworks/ciscoaci-puppet/pull/51