### PR TITLE
Persist gen2 interface when droplog enabled

### DIFF
--- a/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
@@ -3,6 +3,7 @@ class ciscoaci::opflex(
   $aci_apic_systemid,
   $aci_opflex_uplink_interface,
   $opflex_enable_bond_watch,
+  $opflex_enable_drop_log,
   $aci_apic_infra_subnet_gateway = '10.0.0.30',
   $aci_apic_infra_anycast_address = '10.0.0.32',
   $aci_apic_infravlan = '4093',

--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -75,3 +75,17 @@ autorestart=unexpected
 startsecs=0
 <% end %>
 
+<% if @opflex_enable_drop_log == true %>
+[program:ovs-vsctl-add-droplog]
+command=/bin/ovs-vsctl -- --may-exist add-port br-int gen2 -- set interface gen2 type=geneve options:remote_ip=flow options:key=2
+exitcodes=0
+autorestart=unexpected
+startsecs=0
+
+[program:ovs-vsctl-cfg-droplog]
+command=/bin/ovs-vsctl set interface gen2 ingress_policing_rate=1000, ingress_policing_burst=100
+exitcodes=0
+autorestart=unexpected
+startsecs=0
+<% end %>
+


### PR DESCRIPTION
Rebooting the host results in the neutron-cleanup service getting
called, which removes interfaces from the ovs br-int bridge. The
gen2 interface used by droplog (and installed as part of the host-prep
steps in OSP) was getting deleted on reboots because of this.

This adds the creation of the gen2 interface to the opflex agent
container's supervisord configuration file, in order to ensure
that the gen2 interface gets recreated after reboots.