### PR TITLE
Use new JSON parser by default

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs-vlan.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs-vlan.conf.erb
@@ -23,8 +23,13 @@
        // "socket-owner": "root",
        "socket-group": "opflexep",
        "socket-permissions": "770"
-       }
+       },
 
+       "asyncjson" : { "enabled" : "true" }
+    },
+
+    "ovs": {
+        "asyncjson" : { "enabled" : "true" }
     },
 
     "feature": {

--- a/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs.conf.erb
@@ -23,8 +23,13 @@
        // "socket-owner": "root",
        "socket-group": "opflexep",
        "socket-permissions": "770"
-       }
+       },
 
+       "asyncjson" : { "enabled" : "true" }
+    },
+
+    "ovs": {
+        "asyncjson" : { "enabled" : "true" }
     },
 
     "feature": {


### PR DESCRIPTION
Use the new JSON parser by default, if available. For versions of the agent that don't yet support this feature, the configuration JSON is silently ignored.