### PR TITLE
Add agent policy retry delay timer

### DIFF
--- a/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
@@ -32,7 +32,8 @@ class ciscoaci::opflex(
   $opflex_notification_socket = $::ciscoaci::opflex_params::opflex_notification_socket,
   $opflex_inspect_socket = $::ciscoaci::opflex_params::opflex_inspect_socket,
   $opflex_ovsdb_async_parser = 'false',
-  $opflex_opflex_async_parser = 'false'
+  $opflex_opflex_async_parser = 'false',
+  $opflex_retry_delay = '10'
 ) inherits ::ciscoaci::opflex_params 
 {
 

--- a/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs-vlan.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs-vlan.conf.erb
@@ -24,6 +24,9 @@
        "socket-group": "opflexep",
        "socket-permissions": "770"
        },
+       "timers": {
+           "policy-retry-delay": "<%= @oopflex_retry_delay %>"
+       },
 
        "asyncjson" : { "enabled" : "<%= @opflex_opflex_async_parser %>"}
     },

--- a/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs.conf.erb
@@ -24,6 +24,9 @@
        "socket-group": "opflexep",
        "socket-permissions": "770"
        },
+       "timers": {
+           "policy-retry-delay": "<%= @oopflex_retry_delay %>"
+       },
 
        "asyncjson" : { "enabled" : "<%= @opflex_opflex_async_parser %>"}
     },


### PR DESCRIPTION
The opflex-agent was changed to support configuration of the policy retry delay timer. Add a tripleo parameter to allow configuration of the delay timer.