### PR TITLE
Add GARP configuration for gen1 hardware

### DIFF
--- a/ciscoaci-puppet/ciscoaci/manifests/aim_config.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/aim_config.pp
@@ -23,7 +23,8 @@ class ciscoaci::aim_config(
   $aci_provision_hostlinks = 'False',
   $aci_external_routed_domain_name = '',
   $mcast_ranges = '225.2.1.1:225.2.255.255',
-  $multicast_address = '225.1.2.3'
+  $multicast_address = '225.1.2.3',
+  $gen1_hw_gratarps = 'False'
 ) inherits ::ciscoaci::params
 {
 
@@ -49,6 +50,7 @@ class ciscoaci::aim_config(
      'apic/verify_ssl_certificate':               value => 'False';
      'apic/scope_names':                          value => $aci_scope_names;
      'aim/aim_system_id':                         value => $aci_apic_systemid;
+     'aim/support_gen1_hw_gratarps':              value => $gen1_hw_gratarps;
   }  
 
   if !empty($aci_apic_password) {


### PR DESCRIPTION
First generation switches are unable to use GARPs for EP movement detection in hardware when the EP "move" is on the same port..As a result, additional configuraiton is needed in the BD to punt all GARPs to the switch CPU for processing. This patch adds an AIM parameter to control how this behavior is configured in the fabric, with the default configuration to disable it (i.e. default is to not support use of GARPs for EP movement detection on gen1 hardware).