### PR TITLE
Fix semantic versioning for BES

### DIFF
--- a/rpm/pipeline-rpm-script
+++ b/rpm/pipeline-rpm-script
@@ -8,6 +8,8 @@ pipeline {
     }
     environment {
         ARTIFACTORY_USER = 'noiro.gen'
+        // BES build inumbers are lower than our previous workflow, so we need to add an offset so that semantic-versioned upgrades work correctly
+        BUILD_NUMBER=$((${BUILD_NUMBER}+50))
         ARTIFACTORY_URL = 'https://engci-maven.cisco.com/artifactory/noiro-snapshot/ciscoaci-puppet/train/ciscoaci-puppet/$BUILD_NUMBER'
     }
     stages {


### PR DESCRIPTION
Our BES builds have lower build numbers, which prevents semantic versioning from working correctly with older build workflows. This adds an offset to the BES builds so that the versioning for upgrades works correctly.