### PR TITLE
Add iptables-nft monitor

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -82,6 +82,9 @@ startsecs=0
 <% end %>
 
 <% if @opflex_enable_drop_log == true %>
+[program:monitor-droplog]
+command=/bin/sh -c "while true; do sleep 5; sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat --check OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000 || sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat -A OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000; done"
+
 [program:ovs-vsctl-add-droplog]
 command=sudo /usr/bin/neutron-rootwrap /etc/neutron/rootwrap.conf ovs-vsctl -- --may-exist add-port br-int gen2 -- set interface gen2 type=geneve options:remote_ip=flow options:key=2
 exitcodes=0
@@ -93,5 +96,8 @@ command=sudo /usr/bin/neutron-rootwrap /etc/neutron/rootwrap.conf ovs-vsctl set 
 exitcodes=0
 autorestart=unexpected
 startsecs=0
+<% else %>
+[program:monitor-droplog]
+command=/bin/sh -c "while true; do sleep 5; sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat --check OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000 && sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat -D OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000; done"
 <% end %>
 


### PR DESCRIPTION
This is needed to ensure that the iptables-nft entry is populated for the droplog feature on the opflex agent.