### PR TITLE
Ignore logs to stderr

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -92,7 +92,7 @@ startsecs=0
 
 <% if @opflex_enable_drop_log == true %>
 [program:monitor-droplog]
-command=/bin/sh -c "while true; do sleep 5; sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat --check OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000 || sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat -A OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000; done"
+command=/bin/sh -c "while true; do sleep 5; sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat --check OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000 2>/dev/null || sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat -A OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000; done"
 
 [program:ovs-vsctl-add-droplog]
 command=sudo /usr/bin/neutron-rootwrap /etc/neutron/rootwrap.conf ovs-vsctl -- --may-exist add-port br-int gen2 -- set interface gen2 type=geneve options:remote_ip=flow options:key=2
@@ -107,6 +107,6 @@ autorestart=unexpected
 startsecs=0
 <% else %>
 [program:monitor-droplog]
-command=/bin/sh -c "while true; do sleep 5; sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat --check OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000 && sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat -D OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000; done"
+command=/bin/sh -c "while true; do sleep 5; sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat --check OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000 2>/dev/null && sudo neutron-rootwrap /etc/neutron/rootwrap.conf iptables-nft -t nat -D OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000; done"
 <% end %>
 


### PR DESCRIPTION
The recent versions of iptables-nft now log error level messages when the --check option is used to look for an existing rule, but the rule isn't found. This pollutes the supervisord logs for the opflex-agent container. As a result, cat stderr to /dev/null, but rely on the return code for the iptables-nft command to decide whether the rules need to be added or removed.