### PR TITLE
Use rootwrap for netstat commands

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -41,7 +41,7 @@ stderr_logfile=NONE
 
 <% if @opflex_conn_monitor == true %>
 [program:monitor-opflex-conn]
-command=/bin/sh -c "sleep 120; while true; do if ! netstat -natp | grep -q <%= @opflex_peer_port %>; then sleep 60; if ! netstat -natp | grep -q <%= @opflex_peer_port %>; then date >> /var/lib/opflex-agent-ovs/restarts/reset.conf; fi; sleep 60; fi; done"
+command=/bin/sh -c "sleep 120; while true; do if ! sudo neutron-rootwrap /etc/neutron/rootwrap.conf netstat -natp | grep -q <%= @opflex_peer_port %>; then sleep 60; if ! sudo neutron-rootwrap /etc/neutron/rootwrap.conf netstat -natp | grep -q <%= @opflex_peer_port %>; then date >> /var/lib/opflex-agent-ovs/restarts/reset.conf; fi; sleep 60; fi; done"
 <% end %>
 
 [program:monitor-ovs]


### PR DESCRIPTION
The container security requirements have changed, so now the neutron user doesn't have privileges to run the netstat command needed for monitoring the opflex agent's connectivity with its peers. This patch adds the use of rootwrap to allow root privileges for the netstat command (a separate patch in the python-opflex-agent repo will add the rootwrap filters).