### PR TITLE
Add uplink interface for VLAN mode encap

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs-vlan.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs-vlan.conf.erb
@@ -98,6 +98,7 @@
              "encap": {
                  "vlan" : {
                     "uplink-native-iface": "<%= @v_opflex_encap_iface %>",
+                    "uplink-iface": "<%= @real_opflex_uplink_iface %>",
                     "encap-iface": "<%= @v_opflex_encap_iface %>"
                  }
              },


### PR DESCRIPTION
The oipflex-agent needs the uplink-iface parameter configured when using VLAN mode encapsulation, so that it can retrieve the MAC for that interface and use it in the OpFlex identity messages.