### PR TITLE
Limit multicast daemon to VXLAN encap mode

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -60,6 +60,7 @@ stderr_logfile=NONE
 <% end %>
 
 
+<% if @aci_opflex_encap_mode == "vxlan" %>
 [program:mcast-d]
 <% if @opflex_limit_mcast_interfaces == true %>
 command=/usr/bin/mcast_daemon -i <%= @real_opflex_uplink_iface %> --log /var/log/opflex/mcast.log
@@ -74,6 +75,7 @@ stopwaitsecs=10
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE
+<% end %>
 
 <% if @aci_opflex_encap_mode == "vxlan" %>
 [program:ovs-vsctl]


### PR DESCRIPTION
The multicast daemon is only needed when VXLAN encap mode is deployed.