### PR TITLE
Fix opflex connection monitoring

### DIFF
--- a/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex_supervisord.conf.erb
@@ -41,7 +41,7 @@ stderr_logfile=NONE
 
 <% if @opflex_conn_monitor == true %>
 [program:monitor-opflex-conn]
-command=/bin/sh -c "sleep 120; while true; do if ! sudo neutron-rootwrap /etc/neutron/rootwrap.conf netstat -natp | grep -q <%= @opflex_peer_port %>; then sleep 60; if ! sudo neutron-rootwrap /etc/neutron/rootwrap.conf netstat -natp | grep -q <%= @opflex_peer_port %>; then date >> /var/lib/opflex-agent-ovs/restarts/reset.conf; fi; sleep 60; fi; done"
+command=/bin/sh -c "sleep 120; while true; do if ! sudo neutron-rootwrap /etc/neutron/rootwrap.conf netstat -natp | grep -q <%= @opflex_peer_port %>; then sleep 60; if ! sudo neutron-rootwrap /etc/neutron/rootwrap.conf netstat -natp | grep -q <%= @opflex_peer_port %>; then date >> /var/lib/opflex-agent-ovs/restarts/reset.conf; fi; fi; sleep 60; done"
 <% end %>
 
 [program:monitor-ovs]


### PR DESCRIPTION
If the connection is good, then the monitor runs in a tight loop. Change that to ensure that sleeps are done in between the initial checks.