### PR TITLE
Add snats directory for opflex

### DIFF
--- a/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
+++ b/ciscoaci-puppet/ciscoaci/manifests/opflex.pp
@@ -16,6 +16,7 @@ class ciscoaci::opflex(
   $opflex_ssl_mode = 'encrypted',
   $opflex_disabled_features,
   $opflex_endpoint_dir = '/var/lib/opflex-agent-ovs/endpoints',
+  $opflex_snats_dir = '/var/lib/opflex-agent-ovs/snats',
   $opflex_encap_iface = 'br-fab_vxlan0',
   $opflex_remote_port = '8472',
   $opflex_virtual_router = 'true',

--- a/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs-vlan.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs-vlan.conf.erb
@@ -86,6 +86,10 @@
         "filesystem": ["<%= @opflex_endpoint_dir %>"]
     },
 
+    "snat-sources": {
+        "filesystem": ["<%= @opflex_snats_dir %>"]
+    },
+
     "service-sources": {
         "filesystem": ["/var/lib/opflex-agent-ovs/services"]
     },

--- a/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs.conf.erb
+++ b/ciscoaci-puppet/ciscoaci/templates/opflex-agent-ovs.conf.erb
@@ -86,6 +86,10 @@
         "filesystem": ["<%= @opflex_endpoint_dir %>"]
     },
 
+    "snat-sources": {
+        "filesystem": ["<%= @opflex_snats_dir %>"]
+    },
+
     "service-sources": {
         "filesystem": ["/var/lib/opflex-agent-ovs/services"]
     },


### PR DESCRIPTION
The distributed SNAT feature requires access to the snats directory for the opflex agent. Add this configuration to the agent templates.